### PR TITLE
Rename crate from 'bert-rs' to 'bert'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bert-rs"
+name = "bert"
 version = "0.1.0"
 authors = ["Valeryi Savich <Relrin78@gmail.com>"]
 


### PR DESCRIPTION
Every crate on crates.io is for Rust :smile: no reason for the -rs suffix.

@Relrin
